### PR TITLE
Test gateway experiment workflow: environment dispatch

### DIFF
--- a/.github/workflows/test-gateway-experiment.yml
+++ b/.github/workflows/test-gateway-experiment.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.github_environment }}
-      deployment: false
+      deployment: ${{ inputs.github_environment == 'test-gateway' }}
     steps:
       - uses: actions/checkout@v4
       - name: Prove run context


### PR DESCRIPTION
## Summary

Adds a manual **Test gateway experiment** workflow to exercise GitHub Environments from Actions.

- **workflow_dispatch** input `github_environment` with choices `test-gateway` and `test-gateway-no-reviewers`.
- Job `environment.name` follows the selected input.
- `deployment` is `true` only when `github_environment` is `test-gateway` (deployment record); `test-gateway-no-reviewers` runs with `deployment: false`.

## How to verify

Run the workflow from the Actions tab and try each environment option; confirm protection rules and deployment behavior match each environment’s settings.

Made with [Cursor](https://cursor.com)